### PR TITLE
Improved consistency for receive_packet

### DIFF
--- a/bene/node.py
+++ b/bene/node.py
@@ -89,8 +89,8 @@ class Node(object):
             self.deliver_packet(packet, link)
         else:
             # check if unicast packet is for me
-            for link in self.links:
-                if link.address == packet.destination_address:
+            for mylink in self.links:
+                if mylink.address == packet.destination_address:
                     logger.info("%s received packet" % self.hostname)
                     self.deliver_packet(packet, link)
                     return


### PR DESCRIPTION
Right now packets that are received with the default protocol are associated with a link that belongs to the sending node. But packets that are received over a custom protocol are associated with a link that belongs to the receiving node. This change makes the link always belong to the sending node, regardless of protocol.